### PR TITLE
SMARTAPP_BRAIN_TOKEN is not in .env.sample anywhere

### DIFF
--- a/packages/recognizer-smartapp-brain/.env.sample
+++ b/packages/recognizer-smartapp-brain/.env.sample
@@ -1,0 +1,1 @@
+SMARTAPP_BRAIN_TOKEN=<access_token>

--- a/packages/recognizer-smartapp-brain/README.md
+++ b/packages/recognizer-smartapp-brain/README.md
@@ -11,6 +11,12 @@ SmartApp Brain — технология определения смысла фр
 1. Создать проект в https://smartapp-code.sberdevices.ru
 2. Перейти в проект
 3. Настройки проекта -> Классификатор -> __API-ключ Brain__
+4. Добавить токен в `.env` в корне проекта
+
+__.env__
+``` bash
+SMARTAPP_BRAIN_TOKEN=<access_token>
+```
 
 ### Получение интентов
 


### PR DESCRIPTION
Resolve #188
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/recognizer-smartapp-brain@0.7.2-canary.189.b971bb91453740099611f50632ba6f133047a442.0
  npm install @salutejs/recognizer-string-similarity@0.7.2-canary.189.b971bb91453740099611f50632ba6f133047a442.0
  npm install @salutejs/scenario@0.7.2-canary.189.b971bb91453740099611f50632ba6f133047a442.0
  npm install @salutejs/storage-adapter-firebase@0.7.2-canary.189.b971bb91453740099611f50632ba6f133047a442.0
  npm install @salutejs/storage-adapter-memory@0.7.2-canary.189.b971bb91453740099611f50632ba6f133047a442.0
  # or 
  yarn add @salutejs/recognizer-smartapp-brain@0.7.2-canary.189.b971bb91453740099611f50632ba6f133047a442.0
  yarn add @salutejs/recognizer-string-similarity@0.7.2-canary.189.b971bb91453740099611f50632ba6f133047a442.0
  yarn add @salutejs/scenario@0.7.2-canary.189.b971bb91453740099611f50632ba6f133047a442.0
  yarn add @salutejs/storage-adapter-firebase@0.7.2-canary.189.b971bb91453740099611f50632ba6f133047a442.0
  yarn add @salutejs/storage-adapter-memory@0.7.2-canary.189.b971bb91453740099611f50632ba6f133047a442.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
