### PR TITLE
chore: added dimensions in system message

### DIFF
--- a/packages/scenario/src/lib/types/systemMessage.ts
+++ b/packages/scenario/src/lib/types/systemMessage.ts
@@ -111,7 +111,7 @@ export type ListCard = CardBase & {
 /**
  * Возможные размеры отступов
  */
-export type Dimension = '0x' | '1x' | '2x' | '4x' | '5x' | '6x' | '8x' | '9x' | '10x' | '12x' | '16x';
+export type Dimension = '0x' | '1x' | '2x' | '3x' | '4x' | '5x' | '6x' | '7x' | '8x' | '9x' | '10x' | '12x' | '16x';
 export type CellView =
     | LeftRightCellView
     | TextCellView


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/recognizer-smartapp-brain@0.13.1-canary.207.daf97f1e025ffb4587cdf159c180c1653f65bd7d.0
  npm install @salutejs/recognizer-string-similarity@0.13.1-canary.207.daf97f1e025ffb4587cdf159c180c1653f65bd7d.0
  npm install @salutejs/scenario@0.13.1-canary.207.daf97f1e025ffb4587cdf159c180c1653f65bd7d.0
  npm install @salutejs/storage-adapter-firebase@0.13.1-canary.207.daf97f1e025ffb4587cdf159c180c1653f65bd7d.0
  npm install @salutejs/storage-adapter-memory@0.13.1-canary.207.daf97f1e025ffb4587cdf159c180c1653f65bd7d.0
  # or 
  yarn add @salutejs/recognizer-smartapp-brain@0.13.1-canary.207.daf97f1e025ffb4587cdf159c180c1653f65bd7d.0
  yarn add @salutejs/recognizer-string-similarity@0.13.1-canary.207.daf97f1e025ffb4587cdf159c180c1653f65bd7d.0
  yarn add @salutejs/scenario@0.13.1-canary.207.daf97f1e025ffb4587cdf159c180c1653f65bd7d.0
  yarn add @salutejs/storage-adapter-firebase@0.13.1-canary.207.daf97f1e025ffb4587cdf159c180c1653f65bd7d.0
  yarn add @salutejs/storage-adapter-memory@0.13.1-canary.207.daf97f1e025ffb4587cdf159c180c1653f65bd7d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
