### PR TITLE
Не должна очищаться сессия при слотфиллинге

### DIFF
--- a/packages/scenario/src/lib/createScenarioWalker.ts
+++ b/packages/scenario/src/lib/createScenarioWalker.ts
@@ -169,7 +169,7 @@ export const createScenarioWalker = ({
             req.currentState = scenarioState;
             await dispatch(scenarioState.path);
 
-            if (!req.currentState.state.children) {
+            if (!req.currentState.state.children && !session.slotFilling) {
                 session.path = [];
                 session.variables = {};
                 session.currentIntent = undefined;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/recognizer-smartapp-brain@0.17.3-canary.224.67feb01e301f642638c97654ebe2e92e51af04c0.0
  npm install @salutejs/recognizer-string-similarity@0.17.3-canary.224.67feb01e301f642638c97654ebe2e92e51af04c0.0
  npm install @salutejs/scenario@0.17.3-canary.224.67feb01e301f642638c97654ebe2e92e51af04c0.0
  npm install @salutejs/storage-adapter-firebase@0.17.3-canary.224.67feb01e301f642638c97654ebe2e92e51af04c0.0
  npm install @salutejs/storage-adapter-memory@0.17.3-canary.224.67feb01e301f642638c97654ebe2e92e51af04c0.0
  # or 
  yarn add @salutejs/recognizer-smartapp-brain@0.17.3-canary.224.67feb01e301f642638c97654ebe2e92e51af04c0.0
  yarn add @salutejs/recognizer-string-similarity@0.17.3-canary.224.67feb01e301f642638c97654ebe2e92e51af04c0.0
  yarn add @salutejs/scenario@0.17.3-canary.224.67feb01e301f642638c97654ebe2e92e51af04c0.0
  yarn add @salutejs/storage-adapter-firebase@0.17.3-canary.224.67feb01e301f642638c97654ebe2e92e51af04c0.0
  yarn add @salutejs/storage-adapter-memory@0.17.3-canary.224.67feb01e301f642638c97654ebe2e92e51af04c0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
