### PR TITLE
fix: lint error in system message types

### DIFF
--- a/packages/scenario/src/lib/types/systemMessage.ts
+++ b/packages/scenario/src/lib/types/systemMessage.ts
@@ -1047,7 +1047,7 @@ export interface DeepLinkAction {
 /**
  * Действие, которое обозначает копирование текста из карточки в буфер обмена.
  */
- export interface CopyTextAction {
+export interface CopyTextAction {
     /**
      * Тип действия.
      */


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/recognizer-smartapp-brain@0.17.5-canary.227.170623ea291071306bc867812473cff0bc3d5bf8.0
  npm install @salutejs/recognizer-string-similarity@0.17.5-canary.227.170623ea291071306bc867812473cff0bc3d5bf8.0
  npm install @salutejs/scenario@0.17.5-canary.227.170623ea291071306bc867812473cff0bc3d5bf8.0
  npm install @salutejs/storage-adapter-firebase@0.17.5-canary.227.170623ea291071306bc867812473cff0bc3d5bf8.0
  npm install @salutejs/storage-adapter-memory@0.17.5-canary.227.170623ea291071306bc867812473cff0bc3d5bf8.0
  # or 
  yarn add @salutejs/recognizer-smartapp-brain@0.17.5-canary.227.170623ea291071306bc867812473cff0bc3d5bf8.0
  yarn add @salutejs/recognizer-string-similarity@0.17.5-canary.227.170623ea291071306bc867812473cff0bc3d5bf8.0
  yarn add @salutejs/scenario@0.17.5-canary.227.170623ea291071306bc867812473cff0bc3d5bf8.0
  yarn add @salutejs/storage-adapter-firebase@0.17.5-canary.227.170623ea291071306bc867812473cff0bc3d5bf8.0
  yarn add @salutejs/storage-adapter-memory@0.17.5-canary.227.170623ea291071306bc867812473cff0bc3d5bf8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
